### PR TITLE
A "Date Range" loader

### DIFF
--- a/src/main/java/com/mozilla/pig/load/CustomRegExLoader.java
+++ b/src/main/java/com/mozilla/pig/load/CustomRegExLoader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2010 Mozilla Foundation
+ * Copyright 2012 Mozilla Foundation
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,27 +17,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.mozilla.pig.load;
 
-package com.mozilla.util;
+import java.util.regex.Pattern;
 
-public class StringUtil {
+/**
+ * CustomRegExLoader lets you specify an arbitrary Regular Expression to use parsing lines.
+ */
+public class CustomRegExLoader extends RegExLoader {
 
-	public static boolean isBlank(String s) {
-		return (s == null || s.length() == 0 || s.trim().length() == 0);
-	}
-	
-	public static String join(String glue, String... bits) {
-	    if (bits == null)
-	        return null;
-	    if (bits.length == 0)
-	        return "";
+    private final Pattern customPattern;
 
-	    StringBuilder sb = new StringBuilder(bits[0]);
-	    for (int i = 1; i < bits.length; i++) {
-	        sb.append(glue);
-	        sb.append(bits[i]);
-	    }
-	    return sb.toString();
-	}
+    // Default to matching entire line.
+    public CustomRegExLoader() {
+        this.customPattern = Pattern.compile("^(.*)$");
+    }
+
+    public CustomRegExLoader(String aPattern) {
+        this.customPattern = Pattern.compile(aPattern);
+    }
+
+    @Override
+    public Pattern getPattern() {
+        return customPattern;
+    }
 
 }

--- a/src/main/java/com/mozilla/pig/load/DateRangeLoader.java
+++ b/src/main/java/com/mozilla/pig/load/DateRangeLoader.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mozilla.pig.load;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.lib.input.LineRecordReader;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.pig.LoadFunc;
+import org.apache.pig.backend.hadoop.executionengine.mapReduceLayer.PigSplit;
+import org.apache.pig.data.DataByteArray;
+import org.apache.pig.data.Tuple;
+import org.apache.pig.data.TupleFactory;
+
+import com.mozilla.util.DateIterator;
+import com.mozilla.util.DateUtil;
+import com.mozilla.util.StringUtil;
+
+/**
+ * DateRangeLoader lets you load data from a series of locations corresponding to 
+ * a set of dates.
+ */
+public class DateRangeLoader extends LoadFunc {
+
+    private static final Log LOG = LogFactory.getLog(DateRangeLoader.class);
+    private static final String sqlDateFormatSpec = "yyyy-MM-dd";
+    private static final SimpleDateFormat sqlDateFormat = new SimpleDateFormat(sqlDateFormatSpec);
+    private final SimpleDateFormat inputPathFormat;
+    private final Calendar start;
+    private final Calendar end;
+    private LineRecordReader reader = null;
+    
+    public DateRangeLoader(String startDate, String endDate, String format) {
+        inputPathFormat = new SimpleDateFormat(format);
+        start = Calendar.getInstance();
+        end = Calendar.getInstance();
+        try {
+            start.setTime(sqlDateFormat.parse(startDate));
+            end.setTime(sqlDateFormat.parse(endDate));
+        } catch (ParseException e) {
+            // TODO Throw a RuntimeException?
+        }
+    }
+
+    // Use the default sql-like date format
+    public DateRangeLoader(String startDate, String endDate) {
+        this(startDate, endDate, sqlDateFormatSpec);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public InputFormat getInputFormat() throws IOException {
+        return new TextInputFormat();
+    }
+
+    @Override
+    public void setLocation(String location, Job job) throws IOException {
+        final List<String> paths = new ArrayList<String>();
+        final String finalLocation = location;
+        DateUtil.iterateByDay(start.getTimeInMillis(), end.getTimeInMillis(), new DateIterator(){
+            @Override
+            public void see(long aTime) {
+                String aDate = inputPathFormat.format(new Date(aTime));
+                String path = finalLocation.replace("%DATE%", aDate);
+                LOG.info("Adding a location: '" + path + "'");
+                paths.add(path);
+            }
+        });
+        
+        FileInputFormat.setInputPaths(job, StringUtil.join(",", paths.toArray(new String[]{})));
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public void prepareToRead(RecordReader reader, PigSplit split) throws IOException {
+        this.reader = (LineRecordReader) reader;
+    }
+
+    @Override
+    public Tuple getNext() throws IOException {
+        Tuple t = null;
+        while (reader.nextKeyValue()) {
+            Text val = reader.getCurrentValue();
+            if (val != null) {
+                String line = val.toString();
+                t = TupleFactory.getInstance().newTuple();
+                t.append(new DataByteArray(line));
+            }
+        }
+
+        return t;
+    }
+    
+    
+}

--- a/src/main/java/com/mozilla/util/DateIterator.java
+++ b/src/main/java/com/mozilla/util/DateIterator.java
@@ -1,0 +1,5 @@
+package com.mozilla.util;
+
+public interface DateIterator {
+    public void see(long aTime);
+}

--- a/src/main/java/com/mozilla/util/DateUtil.java
+++ b/src/main/java/com/mozilla/util/DateUtil.java
@@ -110,4 +110,33 @@ public class DateUtil {
 	    
 	    return delta;
 	}
+	
+	/**
+	 * Iterate from startMillis to endMillis (including endMillis) in increments of incrementCount * incrementType
+	 * @param startMillis
+	 * @param endMillis
+	 * @param incrementType
+	 * @param incrementCount
+	 * @param iterator
+	 */
+	public static void iterateByTime(long startMillis, long endMillis, int incrementType, int incrementCount, DateIterator iterator) {
+	    Calendar start = Calendar.getInstance();
+        start.setTimeInMillis(startMillis);
+        Calendar end = Calendar.getInstance();
+        end.setTimeInMillis(endMillis);
+        while (!start.after(end)) {
+            iterator.see(start.getTimeInMillis());
+            start.add(incrementType, incrementCount);
+        }
+	}
+	
+	/**
+	 * Iterate from startMillis to endMillis (including endMillis) in increments of one day
+	 * @param startMillis
+	 * @param endMillis
+	 * @param iterator
+	 */
+    public static void iterateByDay(long startMillis, long endMillis, DateIterator iterator) {
+        iterateByTime(startMillis, endMillis, DATE, 1, iterator);
+    }
 }


### PR DESCRIPTION
This loader lets you specify a pattern instead of a specific path for files, as well as a start/end date, and it will replace '%DATE%' in the pattern with each date in the range.

Example:
my_logs = LOAD '/path/to/weblogs/%DATE%'
                      USING com.mozilla.pig.load.SnippetDateLoader('2012-01-01','2012-01-31') AS (...);

This will load all the log files for January 2012:
/path/to/weblogs/2012-01-01
/path/to/weblogs/2012-01-02
...
/path/to/weblogs/2012-01-31
