### PR TITLE
Add a null check to MultiScanTableMapReduceUtil.initMultiScanTableMapperJob

### DIFF
--- a/src/main/java/com/mozilla/hadoop/hbase/mapreduce/MultiScanTableMapReduceUtil.java
+++ b/src/main/java/com/mozilla/hadoop/hbase/mapreduce/MultiScanTableMapReduceUtil.java
@@ -79,7 +79,9 @@ public class MultiScanTableMapReduceUtil {
 	    if (outputKeyClass != null) {
 	    	job.setMapOutputKeyClass(outputKeyClass);
 	    }
-	    job.setMapperClass(mapper);
+        if (mapper != null) {
+            job.setMapperClass(mapper);
+        }
 		job.getConfiguration().set(MultiScanTableInputFormat.INPUT_TABLE, table);
 		job.getConfiguration().set(MultiScanTableInputFormat.SCANS, convertScanArrayToString(scans));
 	}


### PR DESCRIPTION
For the case where we're calling it from pydoop and therefore don't know the mapper class. @mreid-moz
